### PR TITLE
bump proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "beacon-metrics-gazer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -764,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
## Issue Addressed

building with latest rustc fails due to older proc-macro2. 

## Proposed Changes

proc-macro2 v1.0.56 -> v1.0.63

## Additional Info
Just a modification to the Cargo.lock file: `cargo update -p proc-macro2`


See: #4459 / https://github.com/rust-lang/rust/issues/113152