### PR TITLE
Support single item range

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "beacon-metrics-gazer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -80,6 +80,7 @@ dependencies = [
  "hex",
  "hyper",
  "lazy_static",
+ "once_cell",
  "prettytable-rs",
  "prometheus",
  "regex",
@@ -653,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ bytes = "1.4.0"
 byteorder = "1.4.3"
 clap = { version = "4.2.1", features = ["derive"] }
 hyper = { version = "0.14.25", features = ["server"] }
-lazy_static = "1.4.0"
 prettytable-rs = "0.10.0"
 prometheus = "0.13"
 serde = { version = "1.0.159", features = ["derive"] }
@@ -29,6 +28,8 @@ regex = "1.7.3"
 reqwest = { version = "0.11.16", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 url = "2.3.1"
+once_cell = "1.18.0"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/ranges.rs
+++ b/src/ranges.rs
@@ -1,26 +1,34 @@
 use anyhow::{anyhow, Result};
+use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{collections::HashMap, ops::Range};
 
-pub type IndexRanges = Vec<(String, Range<usize>)>;
+pub type IndexGroups = Vec<(String, Vec<usize>)>;
 type IndexRangesJson = HashMap<String, String>;
-
-/// Render ranges for CLI dumps
-pub fn dump_ranges(ranges: &IndexRanges) -> String {
-    ranges
-        .iter()
-        .map(|(s, range)| format!("{}..{}: {}", range.start, range.end, s))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
+type RangesNotGroup = Vec<(Range<usize>, String)>;
 
 /// Parse group file contents flexibly, either as JSON first or then TXT
-pub fn parse_ranges(input: &str) -> Result<IndexRanges> {
-    if let Ok(groups) = parse_ranges_as_json(input) {
-        return Ok(groups);
+pub fn parse_ranges(input: &str) -> Result<IndexGroups> {
+    let ranges = if let Ok(ranges) = parse_ranges_as_json(input) {
+        ranges
+    } else {
+        parse_ranges_as_txt(input)?
+    };
+
+    let mut ranges_grouped = HashMap::new();
+    for (range, s) in ranges {
+        ranges_grouped.entry(s).or_insert(Vec::new()).push(range);
     }
 
-    parse_ranges_as_txt(input)
+    Ok(ranges_grouped
+        .into_iter()
+        .map(|(s, ranges)| {
+            let mut indexes: Vec<_> = ranges.iter().flat_map(|r| r.clone()).collect();
+            indexes.sort_unstable();
+            indexes.dedup();
+            (s, indexes)
+        })
+        .collect())
 }
 
 /// Parse a file contents defining group ranges with format:
@@ -30,14 +38,14 @@ pub fn parse_ranges(input: &str) -> Result<IndexRanges> {
 /// 0..1000 entityA lighthouse-geth-0
 /// 1000..2000 entityB lodestar-nethermind-0
 /// ```
-fn parse_ranges_as_txt(input: &str) -> Result<IndexRanges> {
+fn parse_ranges_as_txt(input: &str) -> Result<RangesNotGroup> {
     let mut result = Vec::new();
 
     for line in input.lines() {
         let line = line.trim();
         if let Some(space_index) = line.find(' ') {
             let (range_str, name) = line.split_at(space_index);
-            result.push((name.trim().to_string(), parse_range(range_str)?));
+            result.push((parse_range(range_str)?, name.trim().to_string()));
         }
     }
 
@@ -51,56 +59,80 @@ fn parse_ranges_as_txt(input: &str) -> Result<IndexRanges> {
 ///   "1000..2000": "entityB lodestar-nethermind-0",
 /// }
 /// ```
-fn parse_ranges_as_json(input: &str) -> Result<IndexRanges> {
+fn parse_ranges_as_json(input: &str) -> Result<RangesNotGroup> {
     let data: IndexRangesJson = serde_json::from_str(input)?;
     let mut result = Vec::new();
     for (range_str, name) in data {
-        result.push((name, parse_range(&range_str)?));
+        result.push((parse_range(&range_str)?, name));
     }
     // serde_json uses HashMap which does not preserve order. Enforce ascending index order
-    result.sort_by_key(|(_, range)| range.start);
+    result.sort_by_key(|(range, _)| range.start);
     Ok(result)
 }
 
 /// Parses a string representing a range with format:
 /// "0-10", "0..10", "[0..10]", "[0-10]", "(0..10)", "[0-10)",
 fn parse_range(input: &str) -> Result<Range<usize>> {
-    let re = Regex::new(r"(\d+)[-.]+(\d+)")?;
-    let captures = re
-        .captures(input)
-        .ok_or_else(|| anyhow!("Invalid range format: {}", input))?;
-    let start: usize = captures[1].parse()?;
-    let end: usize = captures[2].parse()?;
-    Ok(start..end)
+    static RE_MULTI: Lazy<Regex> = Lazy::new(|| Regex::new(r"(\d+)[-.]+(\d+)").unwrap());
+    static RE_SINGLE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(\d+)[:]*$").unwrap());
+
+    if let Some(c) = RE_MULTI.captures(input.trim()) {
+        let start: usize = c[1].parse()?;
+        let end: usize = c[2].parse()?;
+        Ok(start..end)
+    } else if let Some(c) = RE_SINGLE.captures(input.trim()) {
+        let start: usize = c[1].parse()?;
+        Ok(start..start + 1)
+    } else {
+        Err(anyhow!("Invalid range format: {}", input))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// expand range
+    fn er(r: Range<usize>) -> Vec<usize> {
+        r.into_iter().collect()
+    }
+
+    fn parse_ranges_test(input: &str) -> IndexGroups {
+        let mut groups = parse_ranges(input).unwrap();
+        // Ensure stable order for assertion
+        groups.sort_by_key(|(s, _)| s.to_owned());
+        groups
+    }
+
     #[test]
     fn parse_range_test() {
-        let inputs = ["0-10", "0..10", "[0..10]", "[0-10]", "(0..10)", "[0-10)"];
-
-        for input in inputs {
+        for input in [
+            "0-10", "0..10", "0..10:", "[0..10]:", "[0..10]", "[0-10]", "(0..10)", "[0-10)",
+        ] {
             assert_eq!(parse_range(&input).unwrap(), 0..10);
+        }
+    }
+
+    #[test]
+    fn parse_range_single_test() {
+        for input in ["10", "10:", " 10  ", " 10: "] {
+            assert_eq!(parse_range(&input).unwrap(), 10..11);
         }
     }
 
     #[test]
     fn parse_ranges_file_txt_test() {
         assert_eq!(
-            parse_ranges(
+            parse_ranges_test(
                 "
   0..100   entityA lighthouse-geth
   100..200 entityB lodestar-nethermind-1
 
 ",
-            )
-            .unwrap(),
+            ),
             vec![
-                ("entityA lighthouse-geth".to_owned(), 0..100),
-                ("entityB lodestar-nethermind-1".to_owned(), 100..200),
+                ("entityA lighthouse-geth".to_owned(), er(0..100)),
+                ("entityB lodestar-nethermind-1".to_owned(), er(100..200)),
             ]
         );
     }
@@ -108,13 +140,12 @@ mod tests {
     #[test]
     fn parse_ranges_file_json_test() {
         assert_eq!(
-            parse_ranges(
+            parse_ranges_test(
                 "{\"0..100\": \"entityA lighthouse-geth\", \"100..200\": \"entityB lodestar-nethermind-1\"}"
-            )
-            .unwrap(),
+            ),
             vec![
-                ("entityA lighthouse-geth".to_owned(), 0..100),
-                ("entityB lodestar-nethermind-1".to_owned(), 100..200),
+                ("entityA lighthouse-geth".to_owned(), er(0..100)),
+                ("entityB lodestar-nethermind-1".to_owned(), er(100..200)),
             ]
         );
     }
@@ -122,15 +153,36 @@ mod tests {
     #[test]
     fn parse_ranges_file_yaml_test() {
         assert_eq!(
-            parse_ranges(
+            parse_ranges_test(
                 "0..100: entityA lighthouse-geth
 100..200: entityB lodestar-nethermind-1
 ",
-            )
-            .unwrap(),
+            ),
             vec![
-                ("entityA lighthouse-geth".to_owned(), 0..100),
-                ("entityB lodestar-nethermind-1".to_owned(), 100..200),
+                ("entityA lighthouse-geth".to_owned(), er(0..100)),
+                ("entityB lodestar-nethermind-1".to_owned(), er(100..200)),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_ranges_file_single_repeat_test() {
+        assert_eq!(
+            parse_ranges_test(
+                "
+50..55: entityA lighthouse-geth
+57..58: entityA lighthouse-geth
+60: entityA lighthouse-geth
+70: entityA lighthouse-geth
+100..200: entityB lodestar-nethermind-1
+",
+            ),
+            vec![
+                (
+                    "entityA lighthouse-geth".to_owned(),
+                    vec![50, 51, 52, 53, 54, 57, 60, 70]
+                ),
+                ("entityB lodestar-nethermind-1".to_owned(), er(100..200)),
             ]
         );
     }


### PR DESCRIPTION
Allows to set multiple ranges per entity

```yaml
50..55: entityA lighthouse-geth
57..58: entityA lighthouse-geth
60: entityA lighthouse-geth
70: entityA lighthouse-geth
100..200: entityB lodestar-nethermind-1
```

Internally the tool just resolves all ranges into a large vec that's de-duplicated and sorted

Closes https://github.com/dapplion/beacon-metrics-gazer/issues/7