### PR TITLE
Add indexes per group metric

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@ use hyper::header::{HeaderName, CONTENT_TYPE};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, HeaderMap, Request, Response, Server};
 use metrics::{
-    set_gauge, HEAD_PARTICIPATION, INACTIVITY_SCORES, SOURCE_PARTICIPATION, TARGET_PARTICIPATION,
+    set_gauge, HEAD_PARTICIPATION, INACTIVITY_SCORES, INDEXES_PER_GROUP, SOURCE_PARTICIPATION,
+    TARGET_PARTICIPATION,
 };
 use prettytable::{format, Cell, Row, Table};
 use prometheus::{Encoder, TextEncoder};
@@ -179,7 +180,7 @@ fn group_target_participation(
 }
 
 fn set_participation_to_metrics(participation_by_range: &ParticipationByRange) {
-    for (range_name, _, summary) in participation_by_range.iter() {
+    for (range_name, indexes, summary) in participation_by_range.iter() {
         set_gauge(
             &SOURCE_PARTICIPATION,
             &[range_name],
@@ -200,6 +201,7 @@ fn set_participation_to_metrics(participation_by_range: &ParticipationByRange) {
             &[range_name],
             summary.inactivity_scores_avg as f64,
         );
+        set_gauge(&INDEXES_PER_GROUP, &[range_name], indexes.len() as f64);
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,6 +34,14 @@ lazy_static! {
     )
     .unwrap();
 }
+lazy_static! {
+    pub static ref INDEXES_PER_GROUP: GaugeVec = try_create_gauge_vec(
+        "beacon_network_indexes_per_group",
+        "Count of indexes in a labeled group",
+        &["range"]
+    )
+    .unwrap();
+}
 
 /// Attempts to create a `GaugeVec`, returning `Err` if the registry does not accept the gauge
 /// (potentially due to naming conflict).


### PR DESCRIPTION
Add `beacon_network_indexes_per_group` metric to know how many indexes are associated with each group. Allows to do math with the other metrics