### PR TITLE
Add logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,9 +77,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "clap",
+ "env_logger",
  "hex",
  "hyper",
  "lazy_static",
+ "log",
  "once_cell",
  "prettytable-rs",
  "prometheus",
@@ -255,6 +257,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
 ]
 
 [[package]]
@@ -454,6 +469,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,12 +614,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -1079,6 +1097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1383,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ tokio = { version = "1", features = ["full"] }
 url = "2.3.1"
 once_cell = "1.18.0"
 lazy_static = "1.4.0"
+log = "0.4.19"
+env_logger = "0.10.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Options:
       --dump                       Dump participation ranges print to stderr on each fetch
   -p, --port <PORT>                Metrics server port [default: 8080]
       --address <ADDRESS>          Metrics server bind address [default: 127.0.0.1]
+  -v, --verbose                    Increase verbosity level
   -h, --help                       Print help
   -V, --version                    Print version
 


### PR DESCRIPTION
- Adds option `-v` to display debug logs from fetching state + reqwest
- Fix `--dump` option for very large index sets

Sample run print

```
[2023-08-09T09:37:10Z INFO  beacon_metrics_gazer] connecting to beacon URL "https://eth:prAP7jyLJoHzbCa@bn.bootnode-1.srv.devnet-2m-test.ethpandaops.io"
[2023-08-09T09:37:10Z INFO  beacon_metrics_gazer] index ranges ---
    0-365000: lighthouse-geth
    365000-495000: lighthouse-besu
    495000-705000: lighthouse-nethermind
    705000-1170000: prysm-geth
    1170000-1340000: prysm-besu
    1340000-1605000: prysm-nethermind
    1605000-1615000: lodestar-geth
    1615000-1620000: lodestar-nethermind
    1620000-1625000: lodestar-besu
    1625000-1680000: nimbus-geth
    1680000-1700000: nimbus-besu
    1700000-1730000: nimbus-nethermind
    1730000-1920000: teku-geth
    1920000-1990000: teku-besu
    1990000-2100000: teku-nethermind
    
    ---
[2023-08-09T09:37:10Z DEBUG reqwest::connect] starting new connection: https://REDACTED
[2023-08-09T09:37:11Z INFO  beacon_metrics_gazer] beacon genesis Genesis { genesis_time: 1691507100 }
[2023-08-09T09:37:11Z DEBUG reqwest::connect] starting new connection: https://REDACTED
[2023-08-09T09:37:12Z INFO  beacon_metrics_gazer] beacon config ConfigSpec { seconds_per_slot: 12, slots_per_epoch: 32, slots_per_historical_root: 8192, epochs_per_historical_vector: 65536, epochs_per_slashings_vector: 8192 }
[2023-08-09T09:37:12Z INFO  beacon_metrics_gazer] Metrics server is running on http://127.0.0.1:8080
[2023-08-09T09:37:12Z DEBUG beacon_metrics_gazer] fetching head state from https://REDACTED
[2023-08-09T09:37:12Z DEBUG reqwest::connect] starting new connection: https://REDACTED
[2023-08-09T09:37:13Z DEBUG beacon_metrics_gazer] fetch head state request status 200 OK
[2023-08-09T09:37:34Z DEBUG beacon_metrics_gazer] fetch head state downloaded body size 294721198
 Name                  | Range | Source     | Target     | Head 
 lighthouse-nethermind | [0]   | 0.5754857  | 0.60080475 | 0.27756667 
 nimbus-besu           | [0]   | 0.17415    | 0.18965    | 0.10775 
 lighthouse-besu       | [0]   | 0.57584614 | 0.5995538  | 0.27305385 
 nimbus-nethermind     | [0]   | 0.16236667 | 0.18346667 | 0.11 
 teku-geth             | [0]   | 0.20909473 | 0.23430526 | 0.13839474 
 teku-besu             | [0]   | 0.26824287 | 0.2921     | 0.16087143 
 prysm-nethermind      | [0]   | 0.21299623 | 0.22676603 | 0.0966 
 teku-nethermind       | [0]   | 0.1967909  | 0.19393636 | 0.05417273 
 lodestar-nethermind   | [0]   | 0.5174     | 0.588      | 0.344 
 lodestar-geth         | [0]   | 0.219      | 0.2461     | 0.1228 
 lighthouse-geth       | [0]   | 0.5740137  | 0.5986986  | 0.27372327 
 prysm-geth            | [0]   | 0.21132043 | 0.22513978 | 0.09243441 
 prysm-besu            | [0]   | 0.24442941 | 0.25954705 | 0.11318824 
 nimbus-geth           | [0]   | 0.3100909  | 0.3498     | 0.20534545 
 lodestar-besu         | [0]   | 0          | 0          | 0 
```