### PR TITLE
Add initial health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Options:
       --ranges <RANGES>            Index ranges to group IDs as JSON or TXT. Example: `{"0..100": "lh-geth-0", "100..200": "lh-geth-1"}
       --ranges-file <RANGES_FILE>  Local path or URL containing a file with index ranges with the format as defined in --ranges
       --dump                       Dump participation ranges print to stderr on each fetch
+      --skip-health-check          Skip initial health check
   -p, --port <PORT>                Metrics server port [default: 8080]
       --address <ADDRESS>          Metrics server bind address [default: 127.0.0.1]
   -v, --verbose                    Increase verbosity level

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,20 @@ struct BeaconGenesisResponseData {
     genesis_time: String,
 }
 
+/// - 200: Node is ready
+/// - 206: Node is syncing but can serve incomplete data
+/// - 400: Invalid syncing status code
+/// - 503: Node not initialized or having issues
+/// ref: <https://github.com/ethereum/beacon-APIs/blob/06f65bb6bf3d991d5160c08ec1babc54aa2300d5/apis/node/health.yaml#L16>
+pub async fn fetch_health(url: &str, extra_headers: &HeaderMap) -> Result<u16> {
+    let response = reqwest::Client::new()
+        .get(format!("{}/eth/v1/node/health", url))
+        .headers(extra_headers.clone())
+        .send()
+        .await?;
+    Ok(response.status().as_u16())
+}
+
 pub async fn fetch_genesis(url: &str, extra_headers: &HeaderMap) -> Result<Genesis> {
     let response = reqwest::Client::new()
         .get(format!("{}/eth/v1/beacon/genesis", url))


### PR DESCRIPTION
@barnabasbusa reported an issue where for pre-genesis networks the beacon API may not be available until genesis.

This tool's initialization will crash attempting to retrieve genesis. This PR adds a health check to gracefully handle this case and wait for the beacon node to be available